### PR TITLE
Tiny cleanups helping FRPNow to compile

### DIFF
--- a/Control/FRPNow/Core.hs
+++ b/Control/FRPNow/Core.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, LambdaCase,RecursiveDo, FlexibleContexts, ExistentialQuantification, Rank2Types,GeneralizedNewtypeDeriving  #-}
+{-# LANGUAGE DeriveDataTypeable, RecursiveDo, FlexibleContexts, ExistentialQuantification, Rank2Types,GeneralizedNewtypeDeriving  #-}
 -----------------------------------------------------------------------------
 -- |
 

--- a/Control/FRPNow/Private/PrimEv.hs
+++ b/Control/FRPNow/Private/PrimEv.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase  #-}
 module Control.FRPNow.Private.PrimEv(Round, Clock, PrimEv, newClock , callbackp, spawn, spawnOS, curRound, newRound ,observeAt ) where
 
 import Control.Applicative

--- a/Examples/Gloss/Draw.hs
+++ b/Examples/Gloss/Draw.hs
@@ -93,8 +93,8 @@ boxes mousePos buttons = do boxes <- parList ( box `snapshots` clicks LeftButton
   mouseOver r = isInside <$> mousePos <*> r
 
   clicks :: MouseButton	-> EvStream ()
-  clicks m   = edges $ (m `elem`) <$> buttons
-  releases m = edges $ not . (m `elem`) <$> buttons
+  clicks m   = edges $ (m `Set.member`) <$> buttons
+  releases m = edges $ not . (m `Set.member`) <$> buttons
   release m = next (releases m)
   
 

--- a/PaperImpl/PrimEv.hs
+++ b/PaperImpl/PrimEv.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase  #-}
 module PrimEv(Round, Clock, PrimEv, newClock , spawn, curRound, waitEndRound ,observeAt ) where
 
 import ConcFlag


### PR DESCRIPTION
The first commit is straightforward: Apparently there was a switch from lists to sets at some point in time. However, Examples/Gloss/Draw.hs didn't fully reflect this change. With the commit, it works like a charm.

The second commit removes a couple of unnecessary LambdaCase pragmas, for the silly reason that I'm stuck with an ancient GHC on my system (7.4.1) which doesn't know this pragma yet.

Just for the record: FRPNow works just fine with GHC 7.4.1, if one applies the second commit and also changes the `import Prelude` statement in Control/FRPNow/Core.hs to `import Prelude hiding (catch)`.
