### PR TITLE
Fix typos

### DIFF
--- a/Control/FRPNow.hs
+++ b/Control/FRPNow.hs
@@ -6,8 +6,8 @@
 -- Maintainer  :  atzeus@gmail.org
 -- Stability   :  provisional
 -- Portability :  portable
--- 
--- An FRP library with first-class and higher-order behaviors, and interalized IO. 
+--
+-- An FRP library with first-class and higher-order behaviors, and internalized IO. 
 --
 -- Based on the paper <http://www.cse.chalmers.se/~atze/papers/prprfrp.pdf Principled Practical FRP: Forget the past, Change the future, FRPNow!>, ICFP 2015, by Atze van der Ploeg and Koenem Claessem.
 --

--- a/Control/FRPNow/BehaviorEnd.hs
+++ b/Control/FRPNow/BehaviorEnd.hs
@@ -56,8 +56,8 @@ instance Applicative (BehaviorEnd x) where pure = return ; (<*>) = ap
 combineUntil :: (a -> b -> b) -> BehaviorEnd a x -> Behavior b -> Behavior b
 combineUntil f (bx `Until` e) b = (f <$> bx <*> b) `switch` fmap (const b) e
 
--- | Add the values in the behavior of the @Until@ to the front of the list 
--- until the end event happsens.
+-- | Add the values in the behavior of the @Until@ to the front of the list
+-- until the end event happens.
 (.:) :: BehaviorEnd a x -> Behavior [a] -> Behavior [a]
 (.:) = combineUntil (:)
 
@@ -128,7 +128,7 @@ instance Swap f g => Monad (f :. g) where
   return  = Close . return . return
   m >>= f = joinComp (fmap2m f m)
 
--- anoyance that Monad is not a subclass of functor
+-- annoyance that Monad is not a subclass of functor
 fmap2m f = Close . liftM (liftM f) . open
 
 joinComp :: (Swap b e) => (b :. e) ((b :. e) x) -> (b :. e) x

--- a/Control/FRPNow/Core.hs
+++ b/Control/FRPNow/Core.hs
@@ -47,9 +47,9 @@ import Prelude
 --------------------------------------------------------------------}
 
 -- $time
--- The FRPNow interface is centered around behaviors, values that change over time, and events, value that are known from some point in time on.
+-- The FRPNow interface is centered around behaviors, values that change over time, and events, values that are known from some point in time on.
 --
--- What the pure part of the FRPNow interface does is made precise by denotation semantics, i.e. mathematical meaning. The denotational semantics of the pure interface are
+-- What the pure part of the FRPNow interface does is made precise by denotational semantics, i.e. mathematical meaning. The denotational semantics of the pure interface are
 -- 
 -- @ 
 -- type Event a = (Time+,a)
@@ -113,7 +113,7 @@ instance Monad Event where
   (E m)   >>= f = memoE $ bindInternal m f
 
 
--- | A never occuring event
+-- | A never occurring event
 
 never :: Event a
 never = Never
@@ -180,7 +180,7 @@ memoE e = unsafePerformIO $ memoEIO e
   
 -- Section 6.3
 
--- | An behavior is a value that changes over time.
+-- | A behavior is a value that changes over time.
 
 data Behavior a = B (M (a, Event (Behavior a)))
                 | Const a 
@@ -412,7 +412,7 @@ data Env = Env {
 
 type M = ReaderT Env IO
 
--- | A monad that alows you to:
+-- | A monad that allows you to:
 -- 
 --   * Sample the current value of a behavior via 'sampleNow'
 --   * Interact with the outside world via 'async',  'callback' and 'sync'.
@@ -435,7 +435,7 @@ sampleNow (B m) = Now $ fst <$> m
 -- 
 -- The callback can be safely called from any thread. An error occurs if the callback is called more than once. 
 --
--- See 'Control.FRPNow.EvStream.callbackStream' for a callback that can be called repeatidly.
+-- See 'Control.FRPNow.EvStream.callbackStream' for a callback that can be called repeatedly.
 --  
 -- The event occurs strictly later than the time that 
 -- the callback was created, even if the callback is called immediately.
@@ -443,16 +443,16 @@ callback ::  Now (Event a, a -> IO ())
 callback = Now $ do c <- clock <$> ask
                     (pe, cb) <- liftIO $ callbackp c
                     return (toE pe,cb)
--- | Synchronously execte an IO action.
+-- | Synchronously execute an IO action.
 -- 
 -- Use this is for IO actions which do not take a long time, such as 
 -- opening a file or creating a widget.
 sync :: IO a -> Now a
 sync m = Now $ liftIO m
 
--- | Asynchronously execte an IO action, and obtain the event that it is done.
--- 
--- Starts a seperate thread for the IO action, and then immediatly returns the 
+-- | Asynchronously execute an IO action, and obtain the event that it is done.
+--
+-- Starts a separate thread for the IO action, and then immediatly returns the
 -- event that the IO action is done. Since all actions in the 'Now' monad are instantaneous,
 -- the resulting event is guaranteed to occur in the future (not now).
 --
@@ -534,7 +534,7 @@ planM e = plan makeWeakIORef e
 -- | Plan to execute a 'Now' computation.
 --
 -- When given a event carrying a now computation, execute that now computation as soon as the event occurs.
--- If the event has already occured when 'planNow' is called, then the 'Now' computation will be executed immediatly.
+-- If the event has already occurred when 'planNow' is called, then the 'Now' computation will be executed immediately.
 planNow :: Event (Now a) -> Now (Event a)
 planNow e = Now $ 
   do e' <- runE e
@@ -561,7 +561,7 @@ addPlan p = ReaderT $ \env -> modifyIORef (plansRef env)  (SomePlan p :)
 -- Typically, you don't need this function, but instead use a specialized function for whatever library you want to use FRPNow with such as 'Control.FRPNow.GTK.runNowGTK' or 'Control.FRPNow.Gloss.runNowGloss', which themselves are implemented using this function.
 
 initNow :: 
-      (IO (Maybe a) -> IO ()) -- ^ An IO action that schedules some FRP actions to be run. The callee should ensure that all actions that are scheduled are ran on the same thread. If a scheduled action returns @Just x@, then the ending event has occured with value @x@ and now more FRP actions are scheduled.
+      (IO (Maybe a) -> IO ()) -- ^ An IO action that schedules some FRP actions to be run. The callee should ensure that all actions that are scheduled are ran on the same thread. If a scheduled action returns @Just x@, then the ending event has occurred with value @x@ and now more FRP actions are scheduled.
   ->  Now (Event a) -- ^ The @Now@ computation to execute, resulting in the ending event, i.e. the event that stops the FRP system.
   -> IO ()
 initNow schedule (Now m) = 

--- a/Control/FRPNow/EvStream.hs
+++ b/Control/FRPNow/EvStream.hs
@@ -59,13 +59,13 @@ import Debug.Trace
 
 -- | The (abstract) type of event streams.
 --
--- Denotationally, one can think of an eventstream a value 
--- of type 
+-- Denotationally, one can think of an eventstream as a value
+-- of type
 --
 -- > [(Time,a)]
 --
--- Where the points in time are non-strictly increasing.
--- There can be multiple simulatinous events in an event stream.
+-- where the points in time are non-strictly increasing.
+-- There can be multiple simultaneous events in an event stream.
 
 newtype EvStream a = S { getEs :: Behavior (Event [a]) }
 
@@ -138,8 +138,8 @@ repeatEv b = S $ loop where
              return $  (\x -> [x]) <$> e
 
 
--- | Create a behavior from an initial value and 
--- a event stream of updates.
+-- | Create a behavior from an initial value and
+-- an event stream of updates.
 --
 fromChanges :: a -> EvStream a -> Behavior (Behavior a)
 fromChanges i s = loop i where
@@ -284,8 +284,8 @@ beforeEs s e = S $ beforeEv `switch` en
 
 -- | Delay a behavior by one tick of the ``clock''.
 --
--- The event stream functions as the ``clock'': the input behavior is sampled on each 
--- event, and the current value of the output behavior is always the previously sample. 
+-- The event stream functions as the ``clock'': the input behavior is sampled on each
+-- event, and the current value of the output behavior is always the previous sample.
 --
 --  Occasionally useful to prevent immediate feedback loops.
 delay ::  EvStream x -- ^ The event stream that functions as the ``clock''

--- a/Control/FRPNow/Lib.hs
+++ b/Control/FRPNow/Lib.hs
@@ -19,7 +19,7 @@ module Control.FRPNow.Lib(
    edge,
    -- * Events and their ordering
    tryGetEv,
-   hasOccured,
+   hasOccurred,
    first,
    cmpTime,
    EvOrd(..),
@@ -107,7 +107,7 @@ edge b = futuristic $
 
 -- | A (left) fold over a behavior.
 --
--- The inital value of the resulting behavior is @f i x@ where @i@ the initial value given, and @x@ is the current value of the behavior.
+-- The inital value of the resulting behavior is @f i x@ where @i@ is the initial value given, and @x@ is the current value of the behavior.
 --
 foldB :: Eq a => (b -> a -> b) -> b -> Behavior a -> Behavior (Behavior b)
 foldB f i b = loop i where
@@ -124,36 +124,36 @@ sampleUntil :: Eq a => Behavior a -> Event () -> Behavior (Event [a])
 sampleUntil b end  = loop [] where
   loop ss = do s <- b
                let ss' = s : ss
-               e <- hasOccured end
+               e <- hasOccurred end
                if e then return (pure (reverse ss'))
                else do c <- change b
                        join <$> plan (loop ss' <$ c)
 
 
--- | Convert an event into a behavior that gives 
--- @Nothing@ if the event has not occured yet, and @Just@ the value of the event if the event has already occured.
+-- | Convert an event into a behavior that gives
+-- @Nothing@ if the event has not occurred yet, and @Just@ the value of the event if the event has already occurred.
 tryGetEv :: Event a -> Behavior (Maybe a)
 tryGetEv e = pure Nothing `switch` ((pure . Just) <$> e)
 
--- | The resulting behavior states wheter the input event has already occured.
-hasOccured :: Event x -> Behavior Bool
-hasOccured e = False `step` (pure True <$ e)
+-- | The resulting behavior states whether the input event has already occurred.
+hasOccurred :: Event x -> Behavior Bool
+hasOccurred e = False `step` (pure True <$ e)
 
 -- | Gives the first of two events. 
 -- 
 -- If either of the events lies in the future, then the result will be the first of these events.
--- If both events have already occured, the left event is returned.
+-- If both events have already occurred, the left event is returned.
 first :: Event a -> Event a -> Behavior (Event a)
 first l r = whenJust (tryGetEv r `switch` ((pure . Just) <$> l))
 
 -- | Compare the time of two events.
 -- 
--- The resulting behavior gives an event, occuring at the same time 
+-- The resulting behavior gives an event, occurring at the same time
 -- as the earliest input event, of which the value indicates if the event where
--- simultanious, or if one was earlier. 
+-- simultaneous, or if one was earlier.
 --
--- If at the time of sampling both event lie in the past, then 
--- the result is that they are simulatinous.
+-- If at the time of sampling both events lie in the past, then
+-- the result is that they are simultaneous.
 cmpTime :: Event a -> Event b -> Behavior (Event (EvOrd a b))
 cmpTime l r = whenJust (outcome <$> tryGetEv l <*> tryGetEv r) where
   outcome Nothing  Nothing  = Nothing
@@ -161,7 +161,7 @@ cmpTime l r = whenJust (outcome <$> tryGetEv l <*> tryGetEv r) where
   outcome Nothing  (Just y) = Just (RightEarlier y)
   outcome (Just x) (Just y) = Just (Simul x y)
 
--- | The outcome of a 'cmpTime': the events occur simultanious, left is earlier or right is earlier.
+-- | The outcome of a 'cmpTime': the events occur simultaneous, left is earlier or right is earlier.
 data EvOrd l r = Simul l r
                | LeftEarlier l
                | RightEarlier r
@@ -178,7 +178,7 @@ planB e =  whenJust
 
 -- | Obtain the value of the behavior at the time the event occurs
 --
--- If the event has already occured when sampling the resulting behavior,
+-- If the event has already occurred when sampling the resulting behavior,
 -- we sample not the past, but the current value of the input behavior.
 snapshot :: Behavior a -> Event () -> Behavior (Event a)
 snapshot b e =  let e' = (Just <$> b) <$ e
@@ -194,7 +194,7 @@ b <@> e = plan $ fmap (\x -> b <*> pure x) e
 
 
 
--- | A type class to unifying 'planNow' and 'planB'
+-- | A type class to unify 'planNow' and 'planB'
 class Monad b => Plan b where
   plan :: Event (b a) -> b (Event a)
 

--- a/Control/FRPNow/Time.hs
+++ b/Control/FRPNow/Time.hs
@@ -46,8 +46,8 @@ timeFrac t d = do t' <- localTime t
 tagTime :: (Floating time, Ord time) => Behavior time  -> EvStream a -> EvStream (time,a)
 tagTime c s = ((,) <$> c) <@@> s
 
--- | Gives a behavior containing the values of the events in the stream that occured in the last n seconds
-lastInputs :: (Floating time, Ord time) => 
+-- | Gives a behavior containing the values of the events in the stream that occurred in the last n seconds
+lastInputs :: (Floating time, Ord time) =>
     Behavior time -- ^ The "clock" behavior, the behavior monotonically increases with time
     -> time -- ^ The duration of the history to be kept
     -> EvStream a -- ^ The input stream

--- a/FRPNow-GTK/Control/FRPNow/GTK.hs
+++ b/FRPNow-GTK/Control/FRPNow/GTK.hs
@@ -75,8 +75,8 @@ getSimpleSignal s w = getSignal s w id
 -- in our example, a function of type @(ScollType,Double) -> IO ()@ and produces
 -- a function of the form @callback@, in our example @(ScrollType -> Double -> IO Bool)@.
 --
--- In this example we can covert a signal with hander @(ScrollType -> Double -> IO Bool)@ 
--- to an eventstream giving elements of type @(ScrollType,Double)@ by letting the handler return @False@ 
+-- In this example we can convert a signal with handler @(ScrollType -> Double -> IO Bool)@
+-- to an eventstream giving elements of type @(ScrollType,Double)@ by letting the handler return @False@
 -- as follows:
 --
 -- > scrollToEvStream :: Signal widget (ScrollType -> Double -> IO Bool) -> widget -> Now (EvStream (ScrollType,Double))
@@ -93,7 +93,7 @@ getSignal s w conv =
       return res
 
 
--- | Get a clock that gives the time since the creation of the clock in seconds, and updates maximally even given numer of seconds.
+-- | Get a clock that gives the time since the creation of the clock in seconds, and updates maximally even given number of seconds.
 --
 -- The clock is automatically destroyed and all resources associated with the clock are freed 
 -- when the behavior is garbage collected.

--- a/FRPNow-Gloss/Control/FRPNow/Gloss.hs
+++ b/FRPNow-Gloss/Control/FRPNow/Gloss.hs
@@ -74,7 +74,7 @@ runNowGlossPure ::
             Display  -- ^ Display mode.
          -> Color    -- ^ Background color.
          -> Int      -- ^ Maximum number of frames per second 
-         -> (Behavior Time -> EvStream GEvent -> Behavior (Behavior Picture))  -- ^ A now computation giving the picture to be displayed on the screen, taking the behavior of time and the eventstream of gloss events.
+         -> (Behavior Time -> EvStream GEvent -> Behavior (Behavior Picture))  -- ^ A behavior giving the picture to be displayed on the screen, taking the behavior of time and the eventstream of gloss events.
          -> IO ()
 runNowGlossPure disp bg fps b = runNowGloss disp bg fps (\t e -> sample $ b t e)
 


### PR DESCRIPTION
All typos are in the documentation except the function `hasOccured` ~> `hasOccurred`.
